### PR TITLE
Updated etcd image version to v3.4.13-bootstrap-1

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-v3.4.13-bootstrap
+v3.4.13-bootstrap-1

--- a/etcd_bootstrap_script.sh
+++ b/etcd_bootstrap_script.sh
@@ -41,16 +41,20 @@ check_and_start_etcd(){
         "New")
               wget "$BACKUP_ENDPOINT/initialization/start?mode=$1$FAIL_BELOW_REVISION_PARAMETER" -S -O - ;;
         "Progress")
+              sleep 1;
               continue;;
         "Failed")
+              sleep 1;
               continue;;
         "Successful")
               echo "Bootstrap preprocessing end time: $(date)"
               start_managed_etcd
               break
               ;;
+        *)
+              sleep 1;
+              ;;
         esac;
-        sleep 1;
       done
 }
 


### PR DESCRIPTION
```noteworthy operator
Update etcd version from v3.4.13-bootstrap to v3.4.13-bootstrap-1. :warning: This will cause a restart of the etcd.
```