### PR TITLE
Modify oci-builder for image publishing

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -23,6 +23,7 @@ etcd-custom-image:
       traits:
         draft_release: ~
         publish:
+          oci-builder: 'concourse-image-resource'
           dockerimages:
             etcd:
               registry: 'gcr-readwrite'


### PR DESCRIPTION
Signed-off-by: Shreyas Rao <shreyas.sriganesh.rao@sap.com>

**What this PR does / why we need it**:
Copy of https://github.com/gardener/etcd-custom-image/pull/4 onto master branch.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
