### PR TITLE
switch to `docker` as oci-builder

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -23,7 +23,7 @@ etcd-custom-image:
       traits:
         draft_release: ~
         publish:
-          oci-builder: 'concourse-image-resource'
+          oci-builder: 'docker'
           dockerimages:
             etcd:
               registry: 'gcr-readwrite'


### PR DESCRIPTION
docker-image-resource also uses `dockerd` internally. However, `docker` allows us to inject authentication credentials for image-pulls within image-builds.