### PR TITLE
ETCD uses config file which is downloaded from backup-restore server

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-v3.4.13-bootstrap-2
+v3.4.13-bootstrap-3


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR downloads ETCD config file from the HTTP server and use that config file to run ETCD server.
**Which issue(s) this PR fixes**:
Fixes parts of gardener/etcd-backup-restore#322

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
ETCD config file needs to be downloaded from the backup-restore server
```
