### PR TITLE
[rel-v3.4.13-bootstrap] Consider all files in `/var/etcd/ssl/ca/` for root CAs

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-v3.4.13-bootstrap-1
+v3.4.13-bootstrap-2

--- a/etcd_bootstrap_script.sh
+++ b/etcd_bootstrap_script.sh
@@ -5,7 +5,7 @@ VALIDATION_MARKER=/var/etcd/data/validation_marker
 # Add self-signed CA to list of root CA-certificates
 if [ $ENABLE_TLS = 'true' ]
 then
-  cat /var/etcd/ssl/ca/ca.crt >> /etc/ssl/certs/ca-certificates.crt
+  cat /var/etcd/ssl/ca/* >> /etc/ssl/certs/ca-certificates.crt
   if [ $? -ne 0 ]
   then
     echo "failed to update root certificate list"


### PR DESCRIPTION
**What this PR does / why we need it**:
Consider all files in `/var/etcd/ssl/ca/` for root CAs

**Which issue(s) this PR fixes**:
Needed for https://github.com/gardener/etcd-druid/pull/309

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
All files in the `/var/etcd/ssl/ca/` folder are now added to the list of root CA certificates.
```
```noteworthy operator
Update etcd version from v3.4.13-bootstrap-1 to v3.4.13-bootstrap-2
```