### PR TITLE
Write only the ca certificate files to root CA.

### DIFF
--- a/etcd_bootstrap_script.sh
+++ b/etcd_bootstrap_script.sh
@@ -5,7 +5,7 @@ VALIDATION_MARKER=/var/etcd/data/validation_marker
 # Add self-signed CA to list of root CA-certificates
 if [ $ENABLE_TLS = 'true' ]
 then
-  cat /var/etcd/ssl/client/ca/* >> /etc/ssl/certs/ca-certificates.crt
+  cat /var/etcd/ssl/client/ca/*.crt >> /etc/ssl/certs/ca-certificates.crt
   if [ $? -ne 0 ]
   then
     echo "failed to update root certificate list"


### PR DESCRIPTION
**What this PR does / why we need it**:
Only write the content of the files ending with `.crt` in `/var/etcd/ssl/client/ca` directory
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
