### PR TITLE
Switch to Alpine base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,15 @@
 # SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
 # SPDX-License-Identifier: Apache-2.0
 
-FROM gcr.io/etcd-development/etcd:v3.4.13
-
-RUN apt update
-RUN apt install -y bash curl wget
+FROM gcr.io/etcd-development/etcd:v3.4.13 as source
+FROM alpine:3.15.4
 
 WORKDIR /
+
+RUN apk add --update bash curl wget openssl
+
+COPY --from=source /usr/local/bin/etcd /usr/local/bin
+COPY --from=source /usr/local/bin/etcdctl /usr/local/bin
 COPY etcd_bootstrap_script.sh /var/etcd/bin/bootstrap.sh
+
 ENTRYPOINT ["/usr/local/bin/etcd"]

--- a/Dockerfile-e
+++ b/Dockerfile-e
@@ -1,10 +1,14 @@
 # SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
 # SPDX-License-Identifier: Apache-2.0
 
-FROM gcr.io/etcd-development/etcd:%%ETCD_VERSION%%
-
-RUN apt update
-RUN apt install -y bash curl wget
+FROM gcr.io/etcd-development/etcd:%%ETCD_VERSION%% as source
+FROM alpine:3.15.4
 
 WORKDIR /
+
+RUN apk add --update bash curl wget openssl
+
+COPY --from=source /usr/local/bin/etcd /usr/local/bin
+COPY --from=source /usr/local/bin/etcdctl /usr/local/bin
+
 ENTRYPOINT ["/usr/local/bin/etcd"]

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,11 +1,15 @@
 # SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
 # SPDX-License-Identifier: Apache-2.0
 
-FROM gcr.io/etcd-development/etcd:ETCD_VERSION
-
-RUN apt update
-RUN apt install -y bash curl wget
+FROM gcr.io/etcd-development/etcd:ETCD_VERSION as source
+FROM alpine:3.15.4
 
 WORKDIR /
+
+RUN apk add --update bash curl wget openssl
+
+COPY --from=source /usr/local/bin/etcd /usr/local/bin
+COPY --from=source /usr/local/bin/etcdctl /usr/local/bin
 COPY etcd_bootstrap_script.sh /var/etcd/bin/bootstrap.sh
+
 ENTRYPOINT ["/usr/local/bin/etcd"]


### PR DESCRIPTION
**What this PR does / why we need it**:
To solve reported security incidents with OpenLDAP and OpenSSL in the etcd base image, this PR changes the base image to Alpine which also serves as a base for other Gardener components ([ref](https://github.com/gardener/gardener/blob/201673c1f8a356a63b21505ca9c7f6efe725bd48/Dockerfile#L12))

**Special notes for your reviewer**:
I wasn't sure if we still need the `Dockerfile-e`, so I adapted it as well. (cc @shreyas-s-rao)

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The base image of etcd has been set to Alpine 3.15.4.
```
