### PR TITLE
Build Multi-Arch Images 📦

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -13,7 +13,10 @@ etcd-custom-image:
       traits:
         draft_release: ~
         publish:
-          oci-builder: 'docker'
+          oci-builder: docker-buildx
+          platforms:
+          - linux/amd64
+          - linux/arm64
           dockerimages:
             etcd:
               registry: 'gcr-readwrite'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,11 @@
 # SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
 # SPDX-License-Identifier: Apache-2.0
 
-FROM gcr.io/etcd-development/etcd:v3.4.13 as source
+FROM gcr.io/etcd-development/etcd:v3.4.13 as source-amd64
+FROM gcr.io/etcd-development/etcd:v3.4.13-arm64 as source-arm64
+
+FROM source-$TARGETARCH as source
+
 FROM alpine:3.15.4
 
 WORKDIR /

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,7 +1,11 @@
 # SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors
 # SPDX-License-Identifier: Apache-2.0
 
-FROM gcr.io/etcd-development/etcd:ETCD_VERSION as source
+FROM gcr.io/etcd-development/etcd:ETCD_VERSION as source-amd64
+FROM gcr.io/etcd-development/etcd:ETCD_VERSION as source-arm64
+
+FROM source-$TARGETARCH as source
+
 FROM alpine:3.15.4
 
 WORKDIR /

--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-v3.4.13-bootstrap-5
+v3.4.13-bootstrap-6

--- a/etcd_bootstrap_script.sh
+++ b/etcd_bootstrap_script.sh
@@ -22,6 +22,12 @@ trap_and_propagate() {
 }
 
 start_managed_etcd(){
+      arch=$(uname -m)
+      if [ $arch = "aarch64" ] || [ $arch = "arm64" ]; then
+          # Running etcd on ARM has experimental support for version 3.4.x
+          # https://etcd.io/docs/v3.4/op-guide/supported-platform/
+          export ETCD_UNSUPPORTED_ARCH=arm64
+      fi
       rm -rf $VALIDATION_MARKER
       CONFIG_FILE=/etc/etcd.conf.yaml
       curl "$BACKUP_ENDPOINT/config" -o $CONFIG_FILE


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR lets the CI pipeline build multi-arch images including `linux/amd64` and `linux/arm64` images.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy operator
Published docker images for Etcd-Custom-Image are now multi-arch capable. They include `linux/amd64` and `linux/arm64` images.
```
