### PR TITLE
[main] Build Multi-Arch Images 📦

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -23,7 +23,10 @@ etcd-custom-image:
       traits:
         draft_release: ~
         publish:
-          oci-builder: 'docker'
+          oci-builder: docker-buildx
+          platforms:
+          - linux/amd64
+          - linux/arm64
           dockerimages:
             etcd:
               registry: 'gcr-readwrite'


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR lets the CI pipeline build multi-arch images including `linux/amd64` and `linux/arm64` images.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy operator
Published docker images for Etcd-Custom-Image are now multi-arch ready. They support `linux/amd64` and `linux/arm64`.
```