### PR TITLE
Print minimum size in error message

### DIFF
--- a/etcd_bootstrap_script.sh
+++ b/etcd_bootstrap_script.sh
@@ -28,7 +28,7 @@ start_managed_etcd(){
       minimumsize=50
       actualsize=$(wc -c <$CONFIG_FILE)
       if [ $actualsize -le $minimumsize ]; then
-          echo "downloaded config file size is less than $(minimumsize) bytes"
+          echo "downloaded config file size is less than $minimumsize bytes"
           exit 1
       fi
       etcd --config-file $CONFIG_FILE &


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates the bootstrap script to correctly print `minimumsize` in the error message.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
