### PR TITLE
Upgrade alpine image used to build etcd custom image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ FROM gcr.io/etcd-development/etcd:v3.4.13-arm64 as source-arm64
 
 FROM source-$TARGETARCH as source
 
-FROM alpine:3.15.4
+FROM alpine:3.15.6
 
 WORKDIR /
 

--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-v3.4.13-bootstrap-6
+v3.4.13-bootstrap-7


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR upgrades the alpine image used to build etcd custom images

**Which issue(s) this PR fixes**:
Fixes #
CVE-2022-2068
CVE-2022-37434

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy operator
Base alpine image upgraded from `3.15.4` to `3.15.6`
```
