### PR TITLE
Retry curl for etcd configuration in case of error

### DIFF
--- a/etcd_bootstrap_script.sh
+++ b/etcd_bootstrap_script.sh
@@ -24,7 +24,7 @@ trap_and_propagate() {
 start_managed_etcd(){
       rm -rf $VALIDATION_MARKER
       CONFIG_FILE=/etc/etcd.conf.yaml
-      curl "$BACKUP_ENDPOINT/config" -o $CONFIG_FILE
+      curl --retry 5 --retry-delay 5 --retry-all-errors "$BACKUP_ENDPOINT/config" -o $CONFIG_FILE
       minimumsize=50
       actualsize=$(wc -c <$CONFIG_FILE)
       if [ $actualsize -le $minimumsize ]; then


### PR DESCRIPTION
**What this PR does / why we need it**:
Cherry pick of [`826dec`](https://github.com/gardener/etcd-custom-image/pull/26/commits/826dec49ad5c20facb63f5f4ae116a93642165bc)

As part of bootstrapping etcd, etcd-custom-image makes a call to a REST endpoint hosted by etcd-backup-restore to fetch the etcd configuration needed to start the etcd process.
In case of any error from etcd-backup-restore in serving this configuration, etcd-custom-image currently fails and restarts the container

This PR adds a retry to the curl command so that it retries to fetch the configuration before it crashes and restarts the container

**Which issue(s) this PR fixes**:
Fixes #25 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
`Etcd-custom-image` will now retry fetching etcd configuration in case of any error
```
