### PR TITLE
Upgrade alpine image to 3.15.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ FROM gcr.io/etcd-development/etcd:v3.4.13-arm64 as source-arm64
 
 FROM source-$TARGETARCH as source
 
-FROM alpine:3.15.6
+FROM alpine:3.15.7
 
 WORKDIR /
 

--- a/Dockerfile-e
+++ b/Dockerfile-e
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 FROM gcr.io/etcd-development/etcd:%%ETCD_VERSION%% as source
-FROM alpine:3.15.4
+FROM alpine:3.15.7
 
 WORKDIR /
 

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -6,7 +6,7 @@ FROM gcr.io/etcd-development/etcd:ETCD_VERSION as source-arm64
 
 FROM source-$TARGETARCH as source
 
-FROM alpine:3.15.4
+FROM alpine:3.15.7
 
 WORKDIR /
 

--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-v3.4.13-bootstrap-8
+v3.4.13-bootstrap-9


### PR DESCRIPTION
**What this PR does / why we need it**:
Upgrade alpine version used from `v3.15.6` to `v3.15.7`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Base alpine image upgraded from `3.15.6` to `3.15.7`
```
