### PR TITLE
Set umask to 0077 for etcd process

### DIFF
--- a/etcd_bootstrap_script.sh
+++ b/etcd_bootstrap_script.sh
@@ -66,6 +66,13 @@ check_and_start_etcd(){
       done
 }
 
+umask 0077
+if [ $? -ne 0 ]
+then
+      echo "failed to set umask to 0077"
+      exit 1
+fi
+
 echo "Bootstrap preprocessing start time: $(date)"
 if [ ! -f $VALIDATION_MARKER ] ;
 then


### PR DESCRIPTION
**What this PR does / why we need it**:
Set umask to 0077 for etcd process

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/etcd-backup-restore/issues/631

**Special notes for your reviewer**:
cc @AleksandarSavchev 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The `etcd` process now runs with umask set to `0077`, this way the files it creates have no permissions on `group` and `others` level.
```
