### PR TITLE
Bumped up alpine version to 3.18.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ FROM gcr.io/etcd-development/etcd:v3.4.13-arm64 as source-arm64
 
 FROM source-$TARGETARCH as source
 
-FROM alpine:3.15.8
+FROM alpine:3.18.2
 
 WORKDIR /
 

--- a/Dockerfile-e
+++ b/Dockerfile-e
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 FROM gcr.io/etcd-development/etcd:%%ETCD_VERSION%% as source
-FROM alpine:3.15.8
+FROM alpine:3.18.2
 
 WORKDIR /
 

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -6,7 +6,7 @@ FROM gcr.io/etcd-development/etcd:ETCD_VERSION as source-arm64
 
 FROM source-$TARGETARCH as source
 
-FROM alpine:3.15.8
+FROM alpine:3.18.2
 
 WORKDIR /
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR bumps up alpine version to 3.18.2 so that some of the vulnerabilities found in packages installed in older version are removed.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Bumped up the alpine version to 3.18.2 from 3.15.8
```
