### PR TITLE
Cherry-picking the commit for setting umask to 0077 for etcd process

### DIFF
--- a/etcd_bootstrap_script.sh
+++ b/etcd_bootstrap_script.sh
@@ -72,6 +72,13 @@ check_and_start_etcd(){
       done
 }
 
+umask 0077
+if [ $? -ne 0 ]
+then
+      echo "failed to set umask to 0077"
+      exit 1
+fi
+
 echo "Bootstrap preprocessing start time: $(date)"
 if [ ! -f $VALIDATION_MARKER ] ;
 then


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The `etcd` process now runs with umask set to `0077`, this way the files it creates have no permissions on `group` and `others` level.
```
