### PR TITLE
Updated entry point for etcd-custom-image and added CVE categorisation labels

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -26,6 +26,15 @@ etcd-custom-image:
               inputs:
                 repos:
                   source: ~
+              resource_labels:
+              - name: 'gardener.cloud/cve-categorisation'
+                value:
+                  network_exposure: 'private'
+                  authentication_enforced: true
+                  user_interaction: 'gardener-operator'
+                  confidentiality_requirement: 'high'
+                  integrity_requirement: 'high'
+                  availability_requirement: 'high'
         release:
           nextversion: noop
           release_commit_publishing_policy: tag_only

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,4 @@ COPY --from=source /usr/local/bin/etcd /usr/local/bin
 COPY --from=source /usr/local/bin/etcdctl /usr/local/bin
 COPY etcd_bootstrap_script.sh /var/etcd/bin/bootstrap.sh
 
-ENTRYPOINT ["/usr/local/bin/etcd"]
+ENTRYPOINT ["/var/etcd/bin/bootstrap.sh"]

--- a/Dockerfile-e
+++ b/Dockerfile-e
@@ -11,4 +11,4 @@ RUN apk add --update bash curl wget openssl
 COPY --from=source /usr/local/bin/etcd /usr/local/bin
 COPY --from=source /usr/local/bin/etcdctl /usr/local/bin
 
-ENTRYPOINT ["/usr/local/bin/etcd"]
+ENTRYPOINT ["/var/etcd/bin/bootstrap.sh"]

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -16,4 +16,4 @@ COPY --from=source /usr/local/bin/etcd /usr/local/bin
 COPY --from=source /usr/local/bin/etcdctl /usr/local/bin
 COPY etcd_bootstrap_script.sh /var/etcd/bin/bootstrap.sh
 
-ENTRYPOINT ["/usr/local/bin/etcd"]
+ENTRYPOINT ["/var/etcd/bin/bootstrap.sh"]

--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-v3.4.13-bootstrap-11
+v3.4.13-bootstrap-12


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR Updated the entrypoint in the Dockerfile to the bootstrap script
This PR also adds CVE categorisation labels

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy operator
Entrypoint in dockerfile changed from `/usr/local/bin/etcd` to `/var/etcd/bin/bootstrap.sh`
```
```improvement operator
Add CVE categorisations for etcd-custom-image
```
