### PR TITLE
switch GCR -> Artifact-Registry

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -1,7 +1,5 @@
 etcd-custom-image:
-  template: 'default'
   base_definition:
-    repo: ~
     traits:
       version:
           preprocess: 'noop'
@@ -13,7 +11,6 @@ etcd-custom-image:
           interval: '24h'
       steps:
         update_version:
-          image: 'eu.gcr.io/gardener-project/cc/job-image:1.778.0'
           publish_to:
           - source
 
@@ -26,7 +23,6 @@ etcd-custom-image:
           oci-builder: 'docker'
           dockerimages:
             etcd:
-              registry: 'gcr-readwrite'
               image: 'eu.gcr.io/gardener-project/gardener/etcd'
               dockerfile: 'Dockerfile'
               tag_as_latest: True

--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -23,7 +23,7 @@ etcd-custom-image:
           oci-builder: 'docker'
           dockerimages:
             etcd:
-              image: 'eu.gcr.io/gardener-project/gardener/etcd'
+              image: europe-docker.pkg.dev/gardener-project/releases/gardener/etcd
               dockerfile: 'Dockerfile'
               tag_as_latest: True
               inputs:
@@ -33,6 +33,7 @@ etcd-custom-image:
           nextversion: noop
           release_commit_publishing_policy: tag_only
         component_descriptor:
+          ocm_repository: europe-docker.pkg.dev/gardener-project/releases
           component_labels:
           - name: 'cloud.gardener.cnudie/dso/scanning-hints/source_analysis/v1'
             value:


### PR DESCRIPTION
GCR has been deprecated [0] in favour of Artifact-Registry.

Thus, change push-targets for OCI-Images:

- europe-docker.pkg.dev/gardener-project/snapshots for snapshots
- europe-docker.pkg.dev/gardener-project/releases for releases
- europe-docker.pkg.dev/gardener-project/public for combined view of snapshots + releases

[0]
https://cloud.google.com/artifact-registry/docs/transition/transition-from-gcr


**Release note**:

```breaking operator
Change OCI Image Registry from GCR (`eu.gcr.io/gardener-project`) to Artifact-Registry (`europe-docker.pkg.dev/gardener-project/releases`). Users should update their references.

```
