### PR TITLE
Add archival notice to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
-# ⚠️ etcd-custom-image has now been <ins>archived</ins>.
+# ⚠️ etcd-custom-image is <ins>deprecated</ins>, and has now been <ins>archived</ins>.
 ## Please use [etcd-wrapper](https://github.com/gardener/etcd-wrapper) instead.
+This repository will no longer be available from 1st April 2025 onwards.
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+# ⚠️ etcd-custom-image has now been <ins>archived</ins>.
+## Please use [etcd-wrapper](https://github.com/gardener/etcd-wrapper) instead.
+
+<br>
+
 # etcd-custom-image
 [![REUSE status](https://api.reuse.software/badge/github.com/gardener/etcd-custom-image)](https://api.reuse.software/info/github.com/gardener/etcd-custom-image)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
etcd-custom-image will be archived in favour of [etcd-wrapper](https://github.com/gardener/etcd-wrapper). Once this PR is merged, the repository will be archived and be in read-only mode. All CICD pipelines for the repo will be removed, but the images built from this repo will continue to exist.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/invite @ashwani2k @ishan16696 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```action user
Archive etcd-custom-image repository, in favour of etcd-wrapper.
```
